### PR TITLE
Fix DNA origami typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
 
                             <li><u>MIT, Dept. of Biological Engineering</u><br>
                             Advisor: Mark Bathe <br>
-                            Topic: Entropy-driven excitonic energy transport on DNA origmi<br>
+                            Topic: Entropy-driven excitonic energy transport on DNA origami<br>
                             </li> <br>
 
                             <li><u>Max Planck Institute for Dynamics and Self-Organization</u><br>


### PR DESCRIPTION
## Summary
- fix spelling of 'DNA origami' in MIT research experience entry

## Testing
- `grep -n "DNA origami" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_6881af02a2148325893ec5a882d2adc8